### PR TITLE
Fix invalid index error in answer validation

### DIFF
--- a/quiz/views.py
+++ b/quiz/views.py
@@ -36,5 +36,9 @@ def check_answer(request):
         data = json.loads(request.body)
         q_index = data.get('index')
         selected = data.get('selected')
+
+        if not isinstance(q_index, int) or q_index < 0 or q_index >= len(QUESTIONS):
+            return JsonResponse({"error": "invalid question index"}, status=400)
+
         correct = QUESTIONS[q_index]['answer']
         return JsonResponse({"correct": selected == correct})


### PR DESCRIPTION
## Summary
- handle invalid indices in `check_answer` to avoid crashes

## Testing
- `python -m py_compile quiz/views.py`


------
https://chatgpt.com/codex/tasks/task_e_684ecacc8780832baff707fdc8c51035